### PR TITLE
Remover validación del tercer dígito

### DIFF
--- a/src/ValidadorEc.php
+++ b/src/ValidadorEc.php
@@ -223,9 +223,7 @@ class ValidadorEc
         switch ($tipo) {
             case 'cedula':
             case 'ruc_natural':
-                if ($numero < 0 || $numero > 5) {
-                    throw new Exception('Tercer dígito debe ser mayor o igual a 0 y menor a 6 para cédulas y RUC de persona natural');
-                }
+                return true;
                 break;
             case 'ruc_privada':
                 if ($numero != 9) {


### PR DESCRIPTION
Existen muchos inconvenientes al intentar verificar números de cédulas y ruc de extranjeros con documentos en ecuador, por lo que me gustaría removerlo.
Mas información: [https://www.jybaro.com/blog/cedula-de-identidad-ecuatoriana/#actualizacion20170714](https://www.jybaro.com/blog/cedula-de-identidad-ecuatoriana/#actualizacion20170714)