### PR TITLE
Soporte para cédulas de extranjeros 

### DIFF
--- a/src/ValidadorEc.php
+++ b/src/ValidadorEc.php
@@ -187,8 +187,8 @@ class ValidadorEc
      */
     protected function validarCodigoProvincia($numero)
     {
-        if ($numero < 0 || $numero > 24) {
-            throw new Exception('Codigo de Provincia (dos primeros dígitos) no deben ser mayor a 24 ni menores a 0');
+        if ($numero < 0 || $numero > 24 || $numero === 30) {
+            throw new Exception('Codigo de Provincia (dos primeros dígitos) no deben ser mayor a 24 ni menores a 0 o diferente de 30');
         }
 
         return true;


### PR DESCRIPTION
Agrega soporte para cédula de extranjeros donde el valor de la provincia es 30

![81731006-f6adc080-9453-11ea-9a5f-2b51681f1850](https://user-images.githubusercontent.com/62449737/179647094-0122e05c-34cb-4c24-b924-1f688eb184e0.jpeg)
.